### PR TITLE
Set zip_url and zip_checksum to nil by default

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,3 +1,7 @@
+# You must explicitly set these two on your own
+default['artifactory']['zip_url'] = nil
+default['artifactory']['zip_checksum'] = nil
+
 default['artifactory']['home'] = '/var/lib/artifactory'
 default['artifactory']['log_dir'] = '/var/log/artifactory'
 default['artifactory']['catalina_base'] = ::File.join(artifactory['home'], 'tomcat')


### PR DESCRIPTION
This documents them, so to speak, in attributes/default.rb
